### PR TITLE
fix(terraform,helmfile): declare plan/diff outputs 

### DIFF
--- a/helmfile-actions/action.yml
+++ b/helmfile-actions/action.yml
@@ -8,7 +8,13 @@ inputs:
     description: "The directory to run all the commands in"
     required: false
     default: "."
-outputs: {}
+outputs:
+  diff-output:
+    description: "The Helmfile diff command output"
+    value: ${{ steps.main.outputs.output }}
+  diff-has-changes:
+    description: "Whether the diff contained changes"
+    value: ${{ steps.main.outputs.has-changes }}
 runs:
   using: "composite"
   steps:

--- a/helmfile-actions/diff.sh
+++ b/helmfile-actions/diff.sh
@@ -10,7 +10,7 @@ function helmfileDiff {
     echo "Successfully ran helmfile diff command. No changes were found"
     echo "${output}"
     echo
-    echo "::set-output name=has-changes::${hasChanges}"
+    echo "::set-output name=diff-has-changes::${hasChanges}"
     exit ${exitCode}
   fi
 
@@ -50,12 +50,12 @@ ${output}
     echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentsURL}" > /dev/null
   fi
 
-  echo "::set-output name=has-changes::${hasChanges}"
+  echo "::set-output name=diff-has-changes::${hasChanges}"
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
   output="${output//'%'/'%25'}"
   output="${output//$'\n'/'%0A'}"
   output="${output//$'\r'/'%0D'}"
-  echo "::set-output name=output::${output}"
+  echo "::set-output name=diff-output::${output}"
   exit ${exitCode}
 }

--- a/terraform-actions/action.yml
+++ b/terraform-actions/action.yml
@@ -8,7 +8,13 @@ inputs:
     description: "The directory to run all the commands in"
     required: false
     default: "."
-outputs: {}
+outputs:
+  plan-output:
+    description: "The Terraform plan command output"
+    value: ${{ steps.main.outputs.output }}
+  plan-has-changes:
+    description: "Whether the plan contained changes"
+    value: ${{ steps.main.outputs.has-changes }}
 runs:
   using: "composite"
   steps:

--- a/terraform-actions/fmt.sh
+++ b/terraform-actions/fmt.sh
@@ -32,10 +32,5 @@ ${output}
     echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentsURL}" > /dev/null
   fi
 
-  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-  output="${output//'%'/'%25'}"
-  output="${output//$'\n'/'%0A'}"
-  output="${output//$'\r'/'%0D'}"
-  echo "::set-output name=output::${output}"
   exit ${exitCode}
 }

--- a/terraform-actions/init.sh
+++ b/terraform-actions/init.sh
@@ -32,10 +32,5 @@ ${output}
     echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentsURL}" > /dev/null
   fi
 
-  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-  output="${output//'%'/'%25'}"
-  output="${output//$'\n'/'%0A'}"
-  output="${output//$'\r'/'%0D'}"
-  echo "::set-output name=output::${output}"
   exit ${exitCode}
 }

--- a/terraform-actions/plan.sh
+++ b/terraform-actions/plan.sh
@@ -10,7 +10,7 @@ function terraformPlan {
     echo "Successfully ran terraform plan command. No changes were found"
     echo "${output}"
     echo
-    echo "::set-output name=has-changes::${hasChanges}"
+    echo "::set-output name=plan-has-changes::${hasChanges}"
     exit ${exitCode}
   fi
 
@@ -60,12 +60,12 @@ ${output}
     echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentsURL}" > /dev/null
   fi
 
-  echo "::set-output name=has-changes::${hasChanges}"
+  echo "::set-output name=plan-has-changes::${hasChanges}"
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
   output="${output//'%'/'%25'}"
   output="${output//$'\n'/'%0A'}"
   output="${output//$'\r'/'%0D'}"
-  echo "::set-output name=output::${output}"
+  echo "::set-output name=plan-output::${output}"
   exit ${exitCode}
 }

--- a/terraform-actions/validate.sh
+++ b/terraform-actions/validate.sh
@@ -32,10 +32,5 @@ ${output}
     echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentsURL}" > /dev/null
   fi
 
-  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-  output="${output//'%'/'%25'}"
-  output="${output//$'\n'/'%0A'}"
-  output="${output//$'\r'/'%0D'}"
-  echo "::set-output name=output::${output}"
   exit ${exitCode}
 }


### PR DESCRIPTION
For the outputs to be exposed to the outside they must be declared in the action.yml file.

As part of this change I am renaming them to be more specific (e.g. `output` -> `plan-output`) to:
- allow enable different descriptions per subcommand that generates the action
- avoiding overloading the meaning if a more generic name is used

I'm also removing the outputs generated by terraform `init`, `fmt`, and `validate`, since we were not using them anywhere. We can add them back once we identify a real use case. This is not a breaking change since those outputs where never exposed from the action anyway.