### PR TITLE
fix(helmfile-actions): Truncate actual errors

### DIFF
--- a/helmfile-actions/diff.sh
+++ b/helmfile-actions/diff.sh
@@ -32,6 +32,9 @@ function helmfileDiff {
     echo "Error: Failed to run helmfile diff"
     echo "${output}"
     echo
+    
+    # If output is longer than max length (65536 characters), keep last part
+    output=$(echo "${output}" | tail -c 65000 )
   fi
 
   if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && ([ "${hasChanges}" == "true" ] || [ "${commentStatus}" == "Failed" ]); then


### PR DESCRIPTION
We're seeing weird behavior on [this](https://github.com/iStreamPlanet/kubernetes_management/pull/4168) PR where the the comment output and the message output don't match.