### PR TITLE
feat: Add a scanPath argument for TruffleHog

### DIFF
--- a/trufflehog-actions-scan/action.yml
+++ b/trufflehog-actions-scan/action.yml
@@ -7,6 +7,9 @@ inputs:
   scanArguments:
     description: 'Argument options for scan.'
     required: false
+  scanPath:
+    description: 'Path to scan'
+    required: false  
 branding:
   icon: 'shield'
   color: 'yellow'

--- a/trufflehog-actions-scan/entrypoint.sh
+++ b/trufflehog-actions-scan/entrypoint.sh
@@ -8,9 +8,15 @@ if [ -n "${INPUT_SCANARGUMENTS}" ]; then
   args="${INPUT_SCANARGUMENTS}" # Overwrite if new options string is provided
 fi
 
+githubRepo="file://$(pwd)" # Default target repository
+
+if [ -n "${INPUT_SCANPATH}" ]; then
+  githubRepo="${INPUT_SCANPATH}" # Overwrite if new options string is provided
+fi
+
 # By default the 'WORKDIR' of our Docker image is set to the 'GITHUB_WORKSPACE'
 # which is mounted into our image. This means, as long as a checkout action was
 # done before our action runs, we'll have access to the repository.
-githubRepo="file://$(pwd)" # Default target repository
+
 query="$args $githubRepo" # Build args query with repository url
 trufflehog $query

--- a/trufflehog-actions-scan/entrypoint.sh
+++ b/trufflehog-actions-scan/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 githubRepo="file://$(pwd)" # Default target repository
 
 if [ -n "${INPUT_SCANPATH}" ]; then
-  githubRepo="${INPUT_SCANPATH}" # Overwrite if new options string is provided
+  githubRepo="${INPUT_SCANPATH}"
 fi
 
 # By default the 'WORKDIR' of our Docker image is set to the 'GITHUB_WORKSPACE'


### PR DESCRIPTION
Makes this more configurable.  Helpful when checking out multipe
repositories and we can't make assumptions on the path.