### PR TITLE
fix: Pass through arguments to terraform sub commands

### DIFF
--- a/terraform-actions/main.sh
+++ b/terraform-actions/main.sh
@@ -12,6 +12,9 @@ export TF_IN_AUTOMATION=true
 workingDir="$2"
 function main {
   command="$1"
+  firstWord=$(echo ${command} | cut -d' ' -f1)
+  remainingArgs=$(echo ${command} | cut -d' ' -f2-)
+
   scriptDir=$(dirname ${0})
   source ${scriptDir}/apply.sh
   source ${scriptDir}/fmt.sh
@@ -19,21 +22,21 @@ function main {
   source ${scriptDir}/plan.sh
   source ${scriptDir}/validate.sh
 
-  case "${command}" in
+  case "${firstWord}" in
     apply)
-      terraformApply
+      terraformApply ${remainingArgs}
       ;;
     fmt)
-      terraformFmt
+      terraformFmt ${remainingArgs}
       ;;
     init)
-      terraformInit
+      terraformInit ${remainingArgs}
       ;;
     plan)
-      terraformPlan
+      terraformPlan ${remainingArgs}
       ;;
     validate)
-      terraformValidate
+      terraformValidate ${remainingArgs}
       ;;
     *)
       echo "Error: Unrecognized command ${command}"


### PR DESCRIPTION
Turns out that when we were doing this switch statement, we weren't
parsing for the command and then passing on any additional flags.

In later versions of Terraform, the `-lock-timeout` behavior changes to
immediately fail if there's an existing lock instead of waiting for the
lock to be released as the default behavior. When I tried to set
`-lock-timeout`, the commands stopped matching in this switch block.
