### PR TITLE
Skip output buffering of terraform apply (to get streaming output)

### DIFF
--- a/terraform-actions/apply.sh
+++ b/terraform-actions/apply.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 function terraformApply {
-  output=$(terraform apply -no-color -auto-approve -input=false ${*} 2>&1)
+  
+  terraform apply -no-color -auto-approve -input=false ${*} 2>&1
   exitCode=$?
 
+  echo
   if [ ${exitCode} -eq 0 ]; then
     echo "Successfully ran terraform apply command."
   else
     echo "Error: Failed to run terraform apply"
   fi
 
-  echo "${output}"
-  echo
   exit ${exitCode}
 }


### PR DESCRIPTION
...since slow `terraform apply` can leave GitHub Actions hanging for several minutes before any output is finally returned.

