### PR TITLE
chore: mark npm package updates as 'fix'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  commit-message:
+    prefix: fix
+    include: scope
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
So that merging the commit creates a new release