### PR TITLE
chore: updated lint-pr to become a reusable workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,10 +6,23 @@ on:
       - edited
       - synchronize
 
+  workflow_call:
+
 jobs:
-  main:
+  validate_pr_title:
+    name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            - feat
+            - fix
+            - docs
+            - style
+            - refactor
+            - perf
+            - test
+            - chore


### PR DESCRIPTION
The bot that we currently use for validating our pull request comply with semver is not reliable. This PR updates the existing `lint-pr` github workflow to be reusable so it may be used by other github actions