### PR TITLE
fix: removing helmfile repo check

### DIFF
--- a/helmfile-dependency-check/__test__/main.test.ts
+++ b/helmfile-dependency-check/__test__/main.test.ts
@@ -5,7 +5,7 @@ import * as path from "path"
 
 const baseDir = "helmfile-dependency-check/__test__/test-data/"
 
-const {readFileSync} = jest.requireActual("fs")
+const { readFileSync } = jest.requireActual("fs")
 
 beforeEach(() => {
     jest.resetModules()
@@ -19,7 +19,7 @@ afterEach(() => {
 describe("helmfile-dep-update", () => {
     it("helmfile missing", () => {
         const workingDir = path.join(baseDir, "helmfile-missing")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const setOutputMock = jest.spyOn(require("@actions/core"), "setOutput")
 
@@ -30,29 +30,22 @@ describe("helmfile-dep-update", () => {
     })
     it("helmfile missing repositories", () => {
         const workingDir = path.join(baseDir, "helmfile-no-repositories")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const helmfilePath = path.join(workingDir, "helmfile.yaml")
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
-
-        const mockFiles = [
-            helmfileContent,
-        ]
-        require("fs").__setMockFiles(mockFiles)
 
         const setOutputMock = jest.spyOn(require("@actions/core"), "setOutput")
 
         require("../helmfileDepCheck").helmfileDepCheck()
-        
+
         expect(setOutputMock).toHaveBeenCalledWith("helmfile-lock-state", "fresh")
         expect(setOutputMock).toHaveBeenCalledWith("helmfile-lock-updates", [])
     })
     it("helmfile lock fresh", () => {
         const workingDir = path.join(baseDir, "helmfile-lock-fresh")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const helmfilePath = path.join(workingDir, "helmfile.yaml")
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
 
         const helmfileLockPath = path.join(workingDir, "helmfile.lock")
         const helmfileLockContent = readFileSync(helmfileLockPath, "utf-8")
@@ -61,7 +54,6 @@ describe("helmfile-dep-update", () => {
         const freshHelmfileLockContent = readFileSync(freshHelmfileLockPath, "utf-8")
 
         const mockFiles = [
-            helmfileContent,
             helmfileLockContent,
             freshHelmfileLockContent,
         ]
@@ -78,10 +70,9 @@ describe("helmfile-dep-update", () => {
     })
     it("helmfile lock no updates", () => {
         const workingDir = path.join(baseDir, "helmfile-lock-fresh")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const helmfilePath = path.join(workingDir, "helmfile.yaml")
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
 
         const helmfileLockPath = path.join(workingDir, "helmfile.lock")
         const helmfileLockContent = readFileSync(helmfileLockPath, "utf-8")
@@ -90,7 +81,6 @@ describe("helmfile-dep-update", () => {
         const freshHelmfileLockContent = readFileSync(freshHelmfileLockPath, "utf-8")
 
         const mockFiles = [
-            helmfileContent,
             helmfileLockContent,
             freshHelmfileLockContent,
         ]
@@ -107,10 +97,9 @@ describe("helmfile-dep-update", () => {
     })
     it("helmfile lock update", () => {
         const workingDir = path.join(baseDir, "helmfile-lock-update")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const helmfilePath = path.join(workingDir, "helmfile.yaml")
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
 
         const helmfileLockPath = path.join(workingDir, "helmfile.lock")
         const helmfileLockContent = readFileSync(helmfileLockPath, "utf-8")
@@ -119,7 +108,6 @@ describe("helmfile-dep-update", () => {
         const updatedHelmfileLockContent = readFileSync(updatedHelmfileLockPath, "utf-8")
 
         const mockFiles = [
-            helmfileContent,
             helmfileLockContent,
             updatedHelmfileLockContent,
         ]
@@ -151,15 +139,9 @@ describe("helmfile-dep-update", () => {
     })
     it("helmfile lock missing", () => {
         const workingDir = path.join(baseDir, "helmfile-lock-missing")
-        process.env["INPUT_WORKING_DIRECTORY"] =  workingDir
+        process.env["INPUT_WORKING_DIRECTORY"] = workingDir
 
         const helmfilePath = path.join(workingDir, "helmfile.yaml")
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
-
-        const mockFiles = [
-            helmfileContent,
-        ]
-        require("fs").__setMockFiles(mockFiles)
 
         const setOutputMock = jest.spyOn(require("@actions/core"), "setOutput")
 

--- a/helmfile-dependency-check/dist/index.js
+++ b/helmfile-dependency-check/dist/index.js
@@ -6221,13 +6221,6 @@ function helmfileDepCheck() {
             setOutputs(outputs);
             return;
         }
-        const helmfileContent = (0, fs_1.readFileSync)(helmfilePath, "utf-8");
-        const helmfileData = (0, js_yaml_1.safeLoad)(helmfileContent);
-        if (!helmfileData["repositories"]) {
-            // Return early, because there are no dependencies to check
-            setOutputs(outputs);
-            return;
-        }
         const helmfileLockPath = workingDir + "/helmfile.lock";
         if (!(0, fs_1.existsSync)(helmfileLockPath)) {
             outputs.helmfileLockState = HelmfileLockState.MISSING;

--- a/helmfile-dependency-check/helmfileDepCheck.ts
+++ b/helmfile-dependency-check/helmfileDepCheck.ts
@@ -22,7 +22,7 @@ interface ActionOutputs {
     helmfileLockUpdates: HelmfileLockUpdate[];
 }
 
-function setOutputs({helmfileLockState, helmfileLockUpdates}: ActionOutputs): void {
+function setOutputs({ helmfileLockState, helmfileLockUpdates }: ActionOutputs): void {
     setOutput("helmfile-lock-state", helmfileLockState)
     setOutput("helmfile-lock-updates", helmfileLockUpdates)
 }
@@ -30,7 +30,7 @@ function setOutputs({helmfileLockState, helmfileLockUpdates}: ActionOutputs): vo
 export function helmfileDepCheck() {
     try {
         const outputs: ActionOutputs = {
-            helmfileLockState:  HelmfileLockState.FRESH,
+            helmfileLockState: HelmfileLockState.FRESH,
             helmfileLockUpdates: []
         }
 
@@ -42,14 +42,6 @@ export function helmfileDepCheck() {
             setOutputs(outputs)
             return
         }
-        const helmfileContent = readFileSync(helmfilePath, "utf-8")
-        const helmfileData = safeLoad(helmfileContent)
-
-        if (!helmfileData["repositories"]) {
-            // Return early, because there are no dependencies to check
-            setOutputs(outputs)
-            return
-        } 
 
         const helmfileLockPath = workingDir + "/helmfile.lock"
 
@@ -83,7 +75,7 @@ export function helmfileDepCheck() {
             setOutputs(outputs)
             return
         }
-        
+
         if (currentDependencies.length !== newDependencies.length) {
             console.log(`dependency length mismatch after running helmfile deps`)
             setOutputs(outputs)


### PR DESCRIPTION
- Removing the helmfile repo check
- helmfile-dependency-check expects yaml to be loaded for values file. Fails when gotmpl file is loaded.