### PR TITLE
fix: Remove hardcoded path from Terraform workflow and add optional Codefresh API key secret

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,8 @@ on:
         required: true
       ssh_private_key:
         required: true
+      codefresh_api_key:
+        required: false
 
 jobs:
   minimize-previous-comments:
@@ -71,6 +73,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CODEFRESH_API_KEY: ${{ secrets.codefresh_api_key }}
       WORKSPACE: ${{ matrix.workspace }}
       WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -71,7 +71,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      WORKSPACE: clusters/aws/${{ matrix.workspace }}
+      WORKSPACE: ${{ matrix.workspace }}
       WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This was leftover from the workflow it was based on, which is specifically for k_m. It also adds an optional Codefresh API key as an input secret. Unfortunately, I don't think there is another way to provide additional secrets that may be required by Terraform providers.