### PR TITLE
feat(build-workspace-matrix): Add return_all_workspaces option

### DIFF
--- a/build-workspace-matrix/__tests__/main.test.ts
+++ b/build-workspace-matrix/__tests__/main.test.ts
@@ -61,14 +61,32 @@ test("getWorkspaces event:workflow_dispatch returns dispatch workspace", async (
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "workflow_dispatch",
+    allWorkspaces: "false",
   });
   expect(workspaces).toEqual(["clusters/origin-a"]);
 });
 
-test("getWorkspaces event:schedule returns all workspaces", async () => {
+test("getWorkspaces event:schedule returns all workspaces for scheduled job", async () => {
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "schedule",
+    allWorkspaces: "false",
+  });
+  expect(workspaces.sort()).toEqual([
+    "clusters/stream-a",
+    "clusters/stream-b",
+    "clusters/stream-c",
+    "clusters/origin-a",
+    "clusters/origin-b",
+    "clusters/broadcast",
+  ].sort());
+});
+
+test("getWorkspaces event:schedule returns all workspaces, when return_all_workspaces is true", async () => {
+  const workspaces = await getWorkspaces({
+    ...shared,
+    eventName: "schedule",
+    allWorkspaces: "true",
   });
   expect(workspaces.sort()).toEqual([
     "clusters/stream-a",
@@ -89,6 +107,7 @@ test("getWorkspaces event:push/pull_request returns workspaces with changes", as
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "push",
+    allWorkspaces: "false",
   });
   expect(workspaces.sort()).toEqual([
     "clusters/stream-a",
@@ -104,6 +123,7 @@ test("getWorkspaces event:push/pull_request returns all workspaces when global d
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "push",
+    allWorkspaces: "false",
   });
   expect(workspaces.sort()).toEqual([
     "clusters/broadcast",
@@ -123,6 +143,7 @@ test("getWorkspaces event:push/pull_request returns no workspaces when global de
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "push",
+    allWorkspaces: "false",
   });
   expect(workspaces.sort()).toEqual([].sort());
 });
@@ -135,6 +156,7 @@ test("getWorkspaces event:push/pull_request returns workspaces when dependency c
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "push",
+    allWorkspaces: "false",
   });
   expect(workspaces.sort()).toEqual([
     "clusters/stream-a",
@@ -151,6 +173,7 @@ test("getWorkspaces event:push/pull_request returns workspaces when shared depen
   const workspaces = await getWorkspaces({
     ...shared,
     eventName: "push",
+    allWorkspaces: "false",
   });
   expect(workspaces.sort()).toEqual([
     "clusters/origin-a",

--- a/build-workspace-matrix/action.yml
+++ b/build-workspace-matrix/action.yml
@@ -7,6 +7,10 @@ inputs:
   workspaces:
     description: "A newline-separated list of globs or dependency glob expressions ('workspace-glob : dependency-glob') representing specific workspaces"
     required: true
+  return_all_workspaces:
+    description: "Returns all workspaces for PR's regardless if files have changed or not"
+    required: false
+    default: "false"
   workflow_dispatch_workspace:
     description: "A particular workspace to return when the event type is 'workflow_dispatch'"
     required: false

--- a/build-workspace-matrix/dist/index.js
+++ b/build-workspace-matrix/dist/index.js
@@ -11267,6 +11267,7 @@ const changedFiles_1 = __nccwpck_require__(2077);
             eventName: github_1.context.eventName,
             githubToken: (0, core_1.getInput)("github-token", { required: true }),
             workspaceGlobs: (0, core_1.getInput)("workspaces", { required: true }),
+            allWorkspaces: (0, core_1.getInput)("return_all_workspaces", { required: true }),
             globalDependencyGlobs: (0, core_1.getInput)("global_dependencies"),
             dispatchWorkspace: (0, core_1.getInput)("workflow_dispatch_workspace", {
                 required: github_1.context.eventName === "workflow_dispatch",
@@ -11299,7 +11300,7 @@ async function getWorkspaces(input) {
     }
     const workspaces = await getMatchingWorkspaces(globberInputLines.join("\n"));
     (0, core_1.info)(`Found matching workspaces: ${workspaces.join(", ")}`);
-    if (input.eventName === "schedule") {
+    if (input.eventName === "schedule" || input.allWorkspaces === "true") {
         return workspaces;
     }
     const changedFilesList = await (0, changedFiles_1.changedFiles)(input.eventName, input.githubToken);

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -14,6 +14,7 @@ type supportedEvents = (("workflow_dispatch" | "push" | "pull_request") & Webhoo
       eventName: context.eventName as supportedEvents,
       githubToken: getInput("github-token", { required: true }),
       workspaceGlobs: getInput("workspaces", { required: true }),
+      allWorkspaces: getInput("return_all_workspaces", { required: true }),
       globalDependencyGlobs: getInput("global_dependencies"),
       dispatchWorkspace: getInput("workflow_dispatch_workspace", {
         required: context.eventName === "workflow_dispatch",
@@ -38,6 +39,7 @@ export async function getWorkspaces(input: {
   eventName: supportedEvents,
   githubToken: string,
   workspaceGlobs: string,
+  allWorkspaces: string,
   globalDependencyGlobs: string,
   dispatchWorkspace: string,
 }): Promise<string[]> {
@@ -58,7 +60,7 @@ export async function getWorkspaces(input: {
 
   info(`Found matching workspaces: ${workspaces.join(", ")}`);
 
-  if (input.eventName === "schedule") {
+  if (input.eventName === "schedule" || input.allWorkspaces === "true") {
     return workspaces;
   }
 


### PR DESCRIPTION
This add the `return_all_workspaces` option to the `build-workspace-matrix` action, to allow for all workspaces to be returned in PR actions as well as for scheduled jobs.