### PR TITLE
chore(LIVE-9574): Bump js actions from node16 to node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js using asdf
-        uses: asdf-vm/actions/install@v1.1.0
+        uses: asdf-vm/actions/install@v3.0.2
         env:
           NODEJS_CHECK_SIGNATURES: 'no'
       - name: Cache Node.js modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
       - '**/*.ts'
       - '**/package.json'
       - '**/package-lock.json'
+      - 'update-issue/action.yml'
+      - 'minimize-comments/action.yml'
+      - 'helmfile-dependency-check/action.yml'
+      - 'find-path-owners/action.yml'
+      - 'build-workspace-matrix/action.yml'
   push:
     branches:
       - main

--- a/build-workspace-matrix/action.yml
+++ b/build-workspace-matrix/action.yml
@@ -20,5 +20,5 @@ outputs:
   matrix:
     description: "The matrix object of the shape: { workspace: [] }"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/find-path-owners/action.yml
+++ b/find-path-owners/action.yml
@@ -9,5 +9,5 @@ outputs:
   owners:
     description: A JSON-encoded array of matched owners
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/helmfile-dependency-check/action.yml
+++ b/helmfile-dependency-check/action.yml
@@ -1,7 +1,7 @@
 name: "helmfile-dependency-check"
 description: "Check for helmfile dependency updates"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   working_directory:

--- a/minimize-comments/action.yml
+++ b/minimize-comments/action.yml
@@ -13,5 +13,5 @@ inputs:
     description: Newline-separated list of strings that must be present in the body of the comment for it to be minimized. If at least one of the strings in the body is found the comment will be minimized.
     required: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/update-issue/action.yml
+++ b/update-issue/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: The comment to use when closing an existing issue.
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
node16 is end of life and deprecated for GitHub Actions