### PR TITLE
feat: build-workspace-matrix supports Echo flag

### DIFF
--- a/build-workspace-matrix/README.md
+++ b/build-workspace-matrix/README.md
@@ -11,7 +11,13 @@ Builds a matrix of workspaces based on glob patterns and analysis of which files
 ### `workspaces`
 
 **Required** A newline-separated list of globs or dependency glob expressions representing specific workspaces. A `!` can be used to exclude certain patterns.
-A dependency glob expression looks like `foo/*/ : bar/**/*` - if anything under `bar` changes then all workspaces matching `foo/*/` are returned.
+A dependency glob expression looks like `foo/*/ : bar/**/*` - if anything under `bar` changes then all workspaces matching `foo/*/` are returned. Furthermore, the
+dependency glob expression may also contain a `flag` in the form of `foo/*/ : bar/**/* | <flag>`.
+
+#### Flags
+| Flag   | Behavior                                                                                                                          |
+|--------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `Echo` | The tool will return the exact workspace path as specified without attempting to match the glob pattern to an existing directory. |
 
 ### `workflow_dispatch_workspace`
 

--- a/build-workspace-matrix/__tests__/main.test.ts
+++ b/build-workspace-matrix/__tests__/main.test.ts
@@ -29,6 +29,9 @@ clusters/stream-*/ : clusters/modules/stream/**/*.txt
 clusters/stream-*/ : clusters/modules/origin-and-stream/**/*.txt
 clusters/origin-*/ : clusters/modules/origin/**/*.txt
 clusters/origin-*/ : clusters/modules/origin-and-stream/**/*.txt
+# these workspaces are echoed on dependency changes
+baz/foo/           : clusters/modules/foobar/**/*.txt | Echo
+foo/bar/baz/       : clusters/modules/foobar/**/*.txt | Echo
 # the below is excluded
 !clusters/modules/
 `,
@@ -158,5 +161,20 @@ test("getWorkspaces event:push/pull_request returns workspaces when shared depen
     "clusters/stream-a",
     "clusters/stream-b",
     "clusters/stream-c",
+  ].sort());
+});
+
+test("getWorkspaces event:push/pull_request returns workspaces when dependency changes with Echo Flag", async () => {
+  const mockedChangedFiles = jest.mocked(changedFiles);
+  mockedChangedFiles.mockResolvedValue([
+    "clusters/modules/foobar/subdir/file.txt",
+  ])
+  const workspaces = await getWorkspaces({
+    ...shared,
+    eventName: "push",
+  });
+  expect(workspaces.sort()).toEqual([
+    "baz/foo/",
+    "foo/bar/baz/"
   ].sort());
 });

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -55,7 +55,7 @@ export async function getWorkspaces(input: {
     const [workspaceGlob, dependencyGlobWithFlag] = line.split(":").map(s => s.trim())
     globberInputLines.push(workspaceGlob)
     if (typeof dependencyGlobWithFlag === "string") {
-      const [dependencyGlob, flagString] = line.split("|").map(s => s.trim())
+      const [dependencyGlob, flagString] = dependencyGlobWithFlag.split("|").map(s => s.trim())
       const flag : Flag = Flag[flagString as keyof typeof Flag] // flagString can be undefined which would result in flag being undefined and that is fine.
       workspaceDependencies.push({ workspaceGlob, dependencyGlob, flag });
     }

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -84,12 +84,13 @@ export async function getWorkspaces(input: {
   }
 
   const workspacesWithChangedDependencies = new Set<string>();
+  const workspacesToEcho = new Set<string>();
   for (const {workspaceGlob, dependencyGlob, flag } of workspaceDependencies) {
     const changed = changedFilesList.some(minimatch.filter(dependencyGlob));
     if (changed) {
       if (flag === Flag.Echo) {
         info(`Echo flag found: returning workspace path as configured`);
-        workspacesWithChangedDependencies.add(workspaceGlob);
+        workspacesToEcho.add(workspaceGlob);
       } else {
         const affectedWorkspaces = await getMatchingWorkspaces(workspaceGlob);
         info(`Found changed workspace dependency matching glob '${dependencyGlob}: ${affectedWorkspaces.join(", ")}`);
@@ -98,7 +99,8 @@ export async function getWorkspaces(input: {
     }
   }
 
-  return workspaces.filter((w) => changedFilesList.some((f) => f.startsWith(w)) || workspacesWithChangedDependencies.has(w));
+  const filteredWorkspaces = workspaces.filter((w) => changedFilesList.some((f) => f.startsWith(w)) || workspacesWithChangedDependencies.has(w));
+  return filteredWorkspaces.concat(Array.from(workspacesToEcho.values()));
 }
 
 async function getMatchingWorkspaces(globs: string) {


### PR DESCRIPTION
Adding support to `build-workspace-matrix` for flags in the dependency glob expression. The flags are meant to modify the behavior of the tool and or its output.

This PR introduces the `Echo` flag which is meant to cause the tool to simply return the workspace in the dependency glob expression as configured without attempting to minMatch it against existing workspaces.

One use-case for this feature is for automating `terraform plan` accross multiple repositories. For example, the `con-eng-infra` repo hosts the `stream-cluster` module. When the module is updated, a Github action will checkout the `kubernetes_management` repo and run a terraform plan for every `stream-cluster-*` root module in the repo.

E.g:
```yaml
jobs:
  determine-matrix:
    runs-on: ubuntu-latest
    outputs:
      matrix: ${{ steps.build-workspace-matrix.outputs.matrix }}
    steps:
      - uses: actions/checkout@v4
      - id: build-workspace-matrix
        uses: iStreamPlanet/github-actions/build-workspace-matrix@v1.18.0
        with:
          github-token: ${{secrets.GITHUB_TOKEN}}
          workspaces: |
            clusters/aws/us-east-1/stream-prod-use1-c/ : modules/stream-cluster/* | Echo
            clusters/aws/us-east-1/stream-prod-use1-d/ : modules/stream-cluster/* | Echo
            clusters/aws/us-east-1/stream-stage-use1-b/ : modules/stream-cluster/* | Echo
            clusters/aws/us-west-2/stream-prod-usw2-c/ : modules/stream-cluster/* | Echo
            clusters/aws/us-west-2/stream-prod-usw2-d/ : modules/stream-cluster/* | Echo
            clusters/aws/us-west-2/stream-stage-usw2-b/ : modules/stream-cluster/* | Echo
```