### PR TITLE
feat: build-workspace-matrix supports working_directory argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/build-workspace-matrix/README.md
+++ b/build-workspace-matrix/README.md
@@ -25,6 +25,10 @@ A newline-separated list of globs representing dependencies of each workspace. I
 
 If provided, results will be relative to the given path
 
+### `working_directory`
+
+If provided, the action uses the specified path as the root for the purposes of detecting matching workspaces based on the provided glob patterns.
+
 ## Outputs
 
 ### `matrix`

--- a/build-workspace-matrix/action.yml
+++ b/build-workspace-matrix/action.yml
@@ -16,6 +16,9 @@ inputs:
   relative_to_path:
     description: "If provided, results will be relative to the given path"
     required: false
+  working_directory:
+    description: "If provided, the action uses the specified path as the root for the purposes of detecting matching workspaces based on the provided glob patterns."
+    required: false
 outputs:
   matrix:
     description: "The matrix object of the shape: { workspace: [] }"

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -18,6 +18,7 @@ type supportedEvents = (("workflow_dispatch" | "push" | "pull_request") & Webhoo
       dispatchWorkspace: getInput("workflow_dispatch_workspace", {
         required: context.eventName === "workflow_dispatch",
       }),
+      workingDirectory: getInput("working_directory"),
     });
     console.log(
       `Found ${result.length} impacted workspaces: ${result.join(", ")}`
@@ -40,9 +41,13 @@ export async function getWorkspaces(input: {
   workspaceGlobs: string,
   globalDependencyGlobs: string,
   dispatchWorkspace: string,
+  workingDirectory: string,
 }): Promise<string[]> {
   if (input.eventName === "workflow_dispatch") {
     return [input.dispatchWorkspace];
+  }
+  if (input.workingDirectory) {
+    process.chdir(input.workingDirectory);
   }
 
   const workspaceDependencies: { workspaceGlob: string, dependencyGlob: string }[] = [];

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -49,6 +49,7 @@ export async function getWorkspaces(input: {
 
   const cwd = process.cwd();
   if (input.workingDirectory) {
+    info("Changing working directory to: " + input.workingDirectory)
     process.chdir(input.workingDirectory);
   }
 

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -46,6 +46,8 @@ export async function getWorkspaces(input: {
   if (input.eventName === "workflow_dispatch") {
     return [input.dispatchWorkspace];
   }
+
+  const cwd = process.cwd();
   if (input.workingDirectory) {
     process.chdir(input.workingDirectory);
   }
@@ -92,6 +94,7 @@ export async function getWorkspaces(input: {
     }
   }
 
+  process.chdir(cwd);
   return workspaces.filter((w) => changedFilesList.some((f) => f.startsWith(w)) || workspacesWithChangedDependencies.has(w));
 }
 

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -50,7 +50,7 @@ export async function getWorkspaces(input: {
   const cwd = process.cwd();
   if (input.workingDirectory) {
     process.chdir(input.workingDirectory);
-    info("Changed working directory: " + cwd + " -> " + process.cwd());
+    info(`Changed working directory: ${cwd} -> ${process.cwd()}`);
   }
 
   const workspaceDependencies: { workspaceGlob: string, dependencyGlob: string }[] = [];

--- a/build-workspace-matrix/main.ts
+++ b/build-workspace-matrix/main.ts
@@ -49,8 +49,8 @@ export async function getWorkspaces(input: {
 
   const cwd = process.cwd();
   if (input.workingDirectory) {
-    info("Changing working directory to: " + input.workingDirectory)
     process.chdir(input.workingDirectory);
+    info("Changed working directory: " + cwd + " -> " + process.cwd());
   }
 
   const workspaceDependencies: { workspaceGlob: string, dependencyGlob: string }[] = [];


### PR DESCRIPTION
This PR adds support to the `build-workspace-matrix` GithubAction for specifying a `working_directory` for the purposes of returning matching workspaces.