### PR TITLE
feat(argocd-diff): enable argocd auth login option and extended the manifest filter statement

### DIFF
--- a/argocd-diff/action.yml
+++ b/argocd-diff/action.yml
@@ -13,10 +13,10 @@ inputs:
   argocd-password:
     description: "ArgoCD password for login"
     required: true
-  argocd-use-api-token-auth:
-    description: "Use ArgoCD API token for authenticating the CLI instead of username and password"
+  argocd-use-login-auth:
+    description: "Authenticate to the ArgoCD API using a username and password"
     required: false
-    default: "false"
+    default: "true"
   chart-path:
     description: "Path to app of apps manifest"
     required: true
@@ -36,4 +36,4 @@ runs:
     - name: argocd diff
       shell: bash
       id: main
-      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.argocd-user }}" "${{ inputs.argocd-password }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}" "${{ inputs.argocd-use-api-token-auth }}"
+      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.argocd-user }}" "${{ inputs.argocd-password }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}" "${{ inputs.argocd-use-login-auth }}"

--- a/argocd-diff/action.yml
+++ b/argocd-diff/action.yml
@@ -13,6 +13,10 @@ inputs:
   argocd-password:
     description: "ArgoCD password for login"
     required: true
+  argocd-use-api-token-auth:
+    description: "Use ArgoCD API token for authenticating the CLI instead of username and password"
+    required: false
+    default: "false"
   chart-path:
     description: "Path to app of apps manifest"
     required: true
@@ -32,4 +36,4 @@ runs:
     - name: argocd diff
       shell: bash
       id: main
-      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.argocd-user }}" "${{ inputs.argocd-password }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}"
+      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.argocd-user }}" "${{ inputs.argocd-password }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}" "${{ inputs.argocd-use-api-token-auth }}"

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -8,7 +8,7 @@ CHART_PATH="$5"
 CLUSTER_NAME="$6"
 GITHUB_TOKEN="$7"
 VALUES_FILE="$8"
-USE_API_TOKEN_AUTH="$9"
+USE_LOGIN_AUTH="$9"
 
 export ARGOCD_SERVER="${ARGOCD_DOMAIN}"
 
@@ -23,7 +23,7 @@ yq -i '.metadata.namespace="argocd" | del(.metadata.finalizers) | del(.spec.sync
 TMP_APPS=$(yq '.metadata.name' local.yaml -o j -M | tr -d '"')
 yq -s '.metadata.name' local.yaml
 
-if [[ "${USE_API_TOKEN_AUTH,,}" == "false" ]]; then
+if [[ "${USE_LOGIN_AUTH,,}" == "true" ]]; then
   argocd --grpc-web login ${ARGOCD_DOMAIN} --username "${ARGOCD_USER}" --password "${ARGOCD_PASSWORD}"
 fi
 


### PR DESCRIPTION
This PR updates the `argocd-diff` GH action to provide an input for toggling username/password based authentication to the ArgoCD CLI

The PR also extends a filter used in generating the manifests for diff that filters out the argocd tracking-id which is irrelevant for the diff.