### PR TITLE
fix(argocd-diff): clean up password-based login arguments

### DIFF
--- a/argocd-diff/action.yml
+++ b/argocd-diff/action.yml
@@ -7,16 +7,6 @@ inputs:
   argocd-domain:
     description: "ArgoCD domain"
     required: true
-  argocd-user:
-    description: "ArgoCD user for login"
-    required: true
-  argocd-password:
-    description: "ArgoCD password for login"
-    required: true
-  argocd-use-login-auth:
-    description: "Authenticate to the ArgoCD API using a username and password"
-    required: false
-    default: "true"
   chart-path:
     description: "Path to app of apps manifest"
     required: true
@@ -36,4 +26,4 @@ runs:
     - name: argocd diff
       shell: bash
       id: main
-      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.argocd-user }}" "${{ inputs.argocd-password }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}" "${{ inputs.argocd-use-login-auth }}"
+      run: ${{ github.action_path }}/main.sh "${{ inputs.argocd-app }}" "${{ inputs.argocd-domain }}" "${{ inputs.chart-path }}" "${{ inputs.cluster-name }}" "${{ inputs.github-token }}" "${{ inputs.values-file }}"

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -2,13 +2,10 @@
 
 ARGOCD_APP="$1"
 ARGOCD_DOMAIN="$2"
-ARGOCD_USER="$3"
-ARGOCD_PASSWORD="$4"
-CHART_PATH="$5"
-CLUSTER_NAME="$6"
-GITHUB_TOKEN="$7"
-VALUES_FILE="$8"
-USE_LOGIN_AUTH="$9"
+CHART_PATH="$3"
+CLUSTER_NAME="$4"
+GITHUB_TOKEN="$5"
+VALUES_FILE="$6"
 
 export ARGOCD_SERVER="${ARGOCD_DOMAIN}"
 
@@ -22,10 +19,6 @@ helm template ${RELEASE_NAME} ${CHART_PATH} --values ${VALUES_FILE} --debug --va
 yq -i '.metadata.namespace="argocd" | del(.metadata.finalizers) | del(.spec.syncPolicy.automated)' local.yaml
 TMP_APPS=$(yq '.metadata.name' local.yaml -o j -M | tr -d '"')
 yq -s '.metadata.name' local.yaml
-
-if [[ "${USE_LOGIN_AUTH,,}" == "true" ]]; then
-  argocd login ${ARGOCD_DOMAIN} --username "${ARGOCD_USER}" --password "${ARGOCD_PASSWORD}"
-fi
 
 for APP in ${TMP_APPS}; do
   argocd app create ${APP} -f ${APP}.yml --helm-pass-credentials


### PR DESCRIPTION
This PR cleans up the password-based authentication arguments for the argocd-diff GH action as it has been replaced by the preferred env variable based authentication.