### PR TITLE
fix(argocd-diff): generate diff for parent manifest along with child manifests

### DIFF
--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -82,8 +82,7 @@ case $CHILD_DIFF_EXIT_CODE in
     ;;
 esac
 
-REVISION=${GITHUB_REF#refs/heads/}
-PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${REVISION} ; exit ${PIPESTATUS[0]})
+PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${GITHUB_HEAD_REF} ; exit ${PIPESTATUS[0]})
 PARENT_DIFF_EXIT_CODE="$?"
 
 case PARENT_DIFF_EXIT_CODE in

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -13,7 +13,7 @@ echo "Processing parent diff output for ArgoCD app: ${ARGOCD_APP} on cluster: ${
 PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${GITHUB_HEAD_REF} ; exit ${PIPESTATUS[0]})
 PARENT_DIFF_EXIT_CODE="$?"
 
-case PARENT_DIFF_EXIT_CODE in
+case $PARENT_DIFF_EXIT_CODE in
   0)
     PARENT_DIFF_OUTPUT="===== No changes ====="
     echo "${PARENT_DIFF_OUTPUT}"

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -110,8 +110,15 @@ case $CHILD_DIFF_EXIT_CODE in
     ;;
 esac
 
-CHANGES=([ ${CHILD_CHANGES} == "true" ] || [ ${PARENT_CHANGES} == "true" ])
-DIFF_STATUS=([ ${CHILD_DIFF_STATUS} == "Success" ] && [ ${PARENT_DIFF_STATUS} == "Success" ]) || "Failed"
+CHANGES=false
+if [ "${CHILD_CHANGES}" == "true" ] || [ "${PARENT_CHANGES}" == "true" ]; then
+  CHANGES=true
+fi
+
+DIFF_STATUS="Failed"
+if [ "${CHILD_DIFF_STATUS}" == "Success" ] && [ "${PARENT_DIFF_STATUS}" == "Success" ]; then
+  DIFF_STATUS="Success"
+fi
 
 if [ ${CHANGES} == "true" ] || [ ${DIFF_STATUS} == "Failed" ]; then
   echo -e "\n\nDiff detected, posting PR comment"

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -30,7 +30,7 @@ case $PARENT_DIFF_EXIT_CODE in
     echo "${PARENT_DIFF_OUTPUT}"
     PARENT_CHANGES="false"
     PARENT_DIFF_STATUS="Failed"
-    exit $CHILD_DIFF_EXIT_CODE
+    exit $PARENT_DIFF_EXIT_CODE
     ;;
 esac
 

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -10,7 +10,7 @@ VALUES_FILE="$6"
 export ARGOCD_SERVER="${ARGOCD_DOMAIN}"
 
 echo "Processing parent diff output for ArgoCD app: ${ARGOCD_APP} on cluster: ${CLUSTER_NAME}"
-PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${GITHUB_HEAD_REF} ; exit ${PIPESTATUS[0]})
+PARENT_DIFF_OUTPUT=$(argocd app diff "${ARGOCD_APP}" --revision "${GITHUB_HEAD_REF}" ; exit ${PIPESTATUS[0]})
 PARENT_DIFF_EXIT_CODE="$?"
 
 case $PARENT_DIFF_EXIT_CODE in
@@ -110,9 +110,9 @@ case $CHILD_DIFF_EXIT_CODE in
     ;;
 esac
 
-CHANGES=false
+CHANGES="false"
 if [ "${CHILD_CHANGES}" == "true" ] || [ "${PARENT_CHANGES}" == "true" ]; then
-  CHANGES=true
+  CHANGES="true"
 fi
 
 DIFF_STATUS="Failed"

--- a/argocd-diff/main.sh
+++ b/argocd-diff/main.sh
@@ -9,6 +9,32 @@ VALUES_FILE="$6"
 
 export ARGOCD_SERVER="${ARGOCD_DOMAIN}"
 
+echo "Processing parent diff output for ArgoCD app: ${ARGOCD_APP} on cluster: ${CLUSTER_NAME}"
+PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${GITHUB_HEAD_REF} ; exit ${PIPESTATUS[0]})
+PARENT_DIFF_EXIT_CODE="$?"
+
+case PARENT_DIFF_EXIT_CODE in
+  0)
+    PARENT_DIFF_OUTPUT="===== No changes ====="
+    echo "${PARENT_DIFF_OUTPUT}"
+    PARENT_CHANGES="false"
+    PARENT_DIFF_STATUS="Success"
+    ;;
+  1)
+    echo "${PARENT_DIFF_OUTPUT}"
+    PARENT_CHANGES="true"
+    PARENT_DIFF_STATUS="Success"
+    ;;
+  *)
+    echo "Parent diff failed with exit code ${PARENT_DIFF_EXIT_CODE}"
+    echo "${PARENT_DIFF_OUTPUT}"
+    PARENT_CHANGES="false"
+    PARENT_DIFF_STATUS="Failed"
+    exit $CHILD_DIFF_EXIT_CODE
+    ;;
+esac
+
+echo "Processing child diff output for ArgoCD app: ${ARGOCD_APP} on cluster: ${CLUSTER_NAME}"
 RELEASE_NAME="tmp-apps-${CLUSTER_NAME}-${GITHUB_RUN_ID}"
 echo ${RELEASE_NAME}
 if [ $(expr length ${RELEASE_NAME}) -gt 46 ]; then
@@ -76,30 +102,10 @@ case $CHILD_DIFF_EXIT_CODE in
     CHILD_DIFF_STATUS="Success"
     ;;
   *)
+    echo "Child diff failed with exit code ${CHILD_DIFF_EXIT_CODE}"
+    echo "${CHILD_DIFF_OUTPUT}"
     CHILD_CHANGES="false"
     CHILD_DIFF_STATUS="Failed"
-    exit $CHILD_DIFF_EXIT_CODE
-    ;;
-esac
-
-PARENT_DIFF_OUTPUT=$(argocd app diff ${ARGOCD_APP} --revision ${GITHUB_HEAD_REF} ; exit ${PIPESTATUS[0]})
-PARENT_DIFF_EXIT_CODE="$?"
-
-case PARENT_DIFF_EXIT_CODE in
-  0)
-    PARENT_DIFF_OUTPUT="===== No changes ====="
-    echo "${PARENT_DIFF_OUTPUT}"
-    PARENT_CHANGES="false"
-    PARENT_DIFF_STATUS="Success"
-    ;;
-  1)
-    echo "${PARENT_DIFF_OUTPUT}"
-    PARENT_CHANGES="true"
-    PARENT_DIFF_STATUS="Success"
-    ;;
-  *)
-    PARENT_CHANGES="false"
-    PARENT_DIFF_STATUS="Failed"
     exit $CHILD_DIFF_EXIT_CODE
     ;;
 esac


### PR DESCRIPTION
This PR addresses a gap in the diff generated by the Github Action. Currently the action only generates a diff of the child manifests of the ArgoCD app in question but does not report on changes to the Application manifest itself.

See this PR for a sample of the new output:
https://github.com/iStreamPlanet/kubernetes_management/pull/15328